### PR TITLE
add import step

### DIFF
--- a/godot/gut.go
+++ b/godot/gut.go
@@ -19,6 +19,11 @@ func (m *Godot) Gut(ctx context.Context, src *dagger.Directory, testPath string)
 		WithEnvVariable("GOWORK", "off").
 		WithExec([]string{
 			"godot",
+			"--headless",
+			"--import",
+		}).
+		WithExec([]string{
+			"godot",
 			"-d",
 			"-s",
 			"--headless",


### PR DESCRIPTION
Add import step to solve

```
RROR: Some GUT class_names have not been imported.  Please restart the Editor or run godot --headless --import
│ ┃ Missing class_names:  ["GutHookScript", "GutInputFactory", "GutInputSender", "GutMain", "GutStringUtils", "GutTest", "GutUtils"]
│ ┃    at: push_error (core/variant/variant_utility.cpp:1098)
```
